### PR TITLE
Rename extension to Argus Monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the "system-monitor" extension will be documented in this file.
+All notable changes to the "argus-monitor" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 📌 System Monitor – VS Code Extension
+# 📌 Argus Monitor – VS Code Extension
 
 This is a Visual Studio Code extension that displays, in real time, information about your computer’s performance directly in the **status bar** of VS Code.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "system-monitor",
-  "displayName": "system-monitor",
+  "name": "argus-monitor",
+  "displayName": "Argus Monitor",
   "description": "",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as os from 'os';
 import * as si from 'systeminformation';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -6,6 +7,24 @@ export function activate(context: vscode.ExtensionContext) {
     statusBarItem.text = `$(pulse) Monitorando...`;
     statusBarItem.show();
 
+    detectAndStartMonitoring(statusBarItem, context);
+}
+
+function detectAndStartMonitoring(statusBarItem: vscode.StatusBarItem, context: vscode.ExtensionContext) {
+    const platform = os.platform();
+
+    if (platform === 'linux') {
+        statusBarItem.text = 'SO: ${platform}';
+        //startMonitoringLinux(statusBarItem, context);
+    } else if (platform === 'win32') {
+        statusBarItem.text = `Monitoramento para Windows ainda não implementado`;
+        //startMonitoringWindows(statusBarItem);
+    } else {
+        statusBarItem.text = `OS não suportado`;
+    }
+}
+
+function startMonitoringLinux(statusBarItem: vscode.StatusBarItem, context: vscode.ExtensionContext) {
     let interval: NodeJS.Timeout | undefined;
 
     async function updateStats() {
@@ -16,11 +35,13 @@ export function activate(context: vscode.ExtensionContext) {
 
             const cpuUsage = cpu.currentLoad.toFixed(1);
             const ramUsage = ((mem.active / mem.total) * 100).toFixed(1);
-            let text = `CPU: ${cpuUsage}% | RAM: ${ramUsage}%`;
+            let text = `Testando | CPU: ${cpuUsage}% | RAM: ${ramUsage}%`;
+
             if (typeof temp.main === 'number' && !isNaN(temp.main)) {
                 text += ` | Temp: ${temp.main.toFixed(0)}°C`;
             }
-            statusBarItem.text = text;
+
+            statusBarItem.text = 'testando'; //text;
         } catch (err) {
             statusBarItem.text = `Erro ao ler dados`;
             console.error(err);
@@ -39,4 +60,7 @@ export function activate(context: vscode.ExtensionContext) {
     });
 }
 
-export function deactivate() {}
+function startMonitoringWindows(statusBarItem: vscode.StatusBarItem) {
+    // Temporariamente exibe mensagem padrão
+    statusBarItem.text = 'Monitoramento para Windows ainda não implementado';
+}

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-describe('System Monitor Extension', () => {
+describe('Argus Monitor Extension', () => {
     let extension: vscode.Extension<any> | undefined;
 
     beforeEach(() => {

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import sinon from 'sinon';
 
-describe('System Monitor Extension - Métricas', () => {
+describe('Argus Monitor Extension - Métricas', () => {
     let extension: vscode.Extension<any> | undefined;
     let sandbox: sinon.SinonSandbox;
 


### PR DESCRIPTION
Update all references from "system-monitor" to "argus-monitor" to reflect the new name of the extension.