### PR TITLE
OS modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to the "system-monitor" extension will be documented in this file.
+All notable changes to the "argus-monitor" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 📌 System Monitor – VS Code Extension
+# 📌 Argus Monitor – VS Code Extension
 
 This is a Visual Studio Code extension that displays, in real time, information about your computer’s performance directly in the **status bar** of VS Code.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "system-monitor",
-  "displayName": "system-monitor",
+  "name": "argus-monitor",
+  "displayName": "Argus Monitor",
   "description": "",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ function detectAndStartMonitoring(statusBarItem: vscode.StatusBarItem, context: 
     const platform = os.platform();
 
     if (platform === 'linux') {
-        statusBarItem.text = 'SO: ${platform}';
+        statusBarItem.text = `SO: ${platform}`;
         //startMonitoringLinux(statusBarItem, context);
     } else if (platform === 'win32') {
         statusBarItem.text = `Monitoramento para Windows ainda não implementado`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ function startMonitoringLinux(statusBarItem: vscode.StatusBarItem, context: vsco
 
             const cpuUsage = cpu.currentLoad.toFixed(1);
             const ramUsage = ((mem.active / mem.total) * 100).toFixed(1);
-            let text = `Testando | CPU: ${cpuUsage}% | RAM: ${ramUsage}%`;
+            let text = `CPU: ${cpuUsage}% | RAM: ${ramUsage}%`;
 
             if (typeof temp.main === 'number' && !isNaN(temp.main)) {
                 text += ` | Temp: ${temp.main.toFixed(0)}°C`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ function detectAndStartMonitoring(statusBarItem: vscode.StatusBarItem, context: 
 
     if (platform === 'linux') {
         statusBarItem.text = `SO: ${platform}`;
-        //startMonitoringLinux(statusBarItem, context);
+        startMonitoringLinux(statusBarItem, context);
     } else if (platform === 'win32') {
         statusBarItem.text = `Monitoramento para Windows ainda não implementado`;
         //startMonitoringWindows(statusBarItem);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ function detectAndStartMonitoring(statusBarItem: vscode.StatusBarItem, context: 
         startMonitoringLinux(statusBarItem, context);
     } else if (platform === 'win32') {
         statusBarItem.text = `Monitoramento para Windows ainda não implementado`;
-        //startMonitoringWindows(statusBarItem);
+        
     } else {
         statusBarItem.text = `OS não suportado`;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as os from 'os';
 import * as si from 'systeminformation';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -6,6 +7,24 @@ export function activate(context: vscode.ExtensionContext) {
     statusBarItem.text = `$(pulse) Monitorando...`;
     statusBarItem.show();
 
+    detectAndStartMonitoring(statusBarItem, context);
+}
+
+function detectAndStartMonitoring(statusBarItem: vscode.StatusBarItem, context: vscode.ExtensionContext) {
+    const platform = os.platform();
+
+    if (platform === 'linux') {
+        statusBarItem.text = 'SO: ${platform}';
+        //startMonitoringLinux(statusBarItem, context);
+    } else if (platform === 'win32') {
+        statusBarItem.text = `Monitoramento para Windows ainda não implementado`;
+        //startMonitoringWindows(statusBarItem);
+    } else {
+        statusBarItem.text = `OS não suportado`;
+    }
+}
+
+function startMonitoringLinux(statusBarItem: vscode.StatusBarItem, context: vscode.ExtensionContext) {
     let interval: NodeJS.Timeout | undefined;
 
     async function updateStats() {
@@ -16,11 +35,13 @@ export function activate(context: vscode.ExtensionContext) {
 
             const cpuUsage = cpu.currentLoad.toFixed(1);
             const ramUsage = ((mem.active / mem.total) * 100).toFixed(1);
-            let text = `CPU: ${cpuUsage}% | RAM: ${ramUsage}%`;
+            let text = `Testando | CPU: ${cpuUsage}% | RAM: ${ramUsage}%`;
+
             if (typeof temp.main === 'number' && !isNaN(temp.main)) {
                 text += ` | Temp: ${temp.main.toFixed(0)}°C`;
             }
-            statusBarItem.text = text;
+
+            statusBarItem.text = 'testando'; //text;
         } catch (err) {
             statusBarItem.text = `Erro ao ler dados`;
             console.error(err);
@@ -39,4 +60,7 @@ export function activate(context: vscode.ExtensionContext) {
     });
 }
 
-export function deactivate() {}
+function startMonitoringWindows(statusBarItem: vscode.StatusBarItem) {
+    // Temporariamente exibe mensagem padrão
+    statusBarItem.text = 'Monitoramento para Windows ainda não implementado';
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,7 @@ function startMonitoringLinux(statusBarItem: vscode.StatusBarItem, context: vsco
                 text += ` | Temp: ${temp.main.toFixed(0)}°C`;
             }
 
-            statusBarItem.text = 'testando'; //text;
+            statusBarItem.text = text;
         } catch (err) {
             statusBarItem.text = `Erro ao ler dados`;
             console.error(err);

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-describe('System Monitor Extension', () => {
+describe('Argus Monitor Extension', () => {
     let extension: vscode.Extension<any> | undefined;
 
     beforeEach(() => {

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import sinon from 'sinon';
 
-describe('System Monitor Extension - Métricas', () => {
+describe('Argus Monitor Extension - Métricas', () => {
     let extension: vscode.Extension<any> | undefined;
     let sandbox: sinon.SinonSandbox;
 


### PR DESCRIPTION
This pull request introduces a rebranding of the extension from "System Monitor" to "Argus Monitor" and lays the groundwork for platform-specific monitoring logic. The most important changes include updates to naming throughout the codebase, the addition of platform detection logic, and the initial structure for supporting Linux and Windows monitoring.

**Rebranding and Naming Updates:**
* Renamed the extension from "system-monitor" to "argus-monitor" in `package.json`, `README.md`, `CHANGELOG.md`, and all test descriptions to reflect the new product identity. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R3) [[4]](diffhunk://#diff-a06b4fb81cd89a490538b13d9e2f3823e9873b12c8de0febbc9f188cc5ea4cc6L4-R4) [[5]](diffhunk://#diff-46aa8b4fca7c1af333179ae03d59de3424dd4fc604fda7adb8eb46ef56add082L7-R7)

**Platform Detection and Monitoring Structure:**
* Added platform detection using the `os` module in `src/extension.ts`, and created the `detectAndStartMonitoring` function to handle Linux, Windows, and unsupported OS cases.
* Stubbed out platform-specific monitoring functions: `startMonitoringLinux` (with initial code) and `startMonitoringWindows` (currently displays a placeholder message). [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R2-R27) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L42-R66)

**Status Bar Messaging:**
* Updated status bar messages to reflect platform detection and monitoring status, including placeholder texts for Linux and Windows implementations. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R2-R27) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L19-R44) [[3]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L42-R66)